### PR TITLE
Add new `Item#toPair()` class method (#3)

### DIFF
--- a/src/item.js
+++ b/src/item.js
@@ -17,6 +17,10 @@ class Item {
   set value(value) {
     this._value = value;
   }
+
+  toPair() {
+    return [this.priority, this.value];
+  }
 }
 
 module.exports = Item;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Item#toPair()`

The method returns an ordered-pair/2-tuple, where the first element is a number corresponding to the `priority` of the item, and the last one is a value, that can be of any type, corresponding to the `value` stored in the item.