### PR TITLE
Add new `Queue#toPairs()` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -25,6 +25,12 @@ class Queue {
   isEmpty() {
     return this._queue.length === 0;
   }
+
+  toPairs() {
+    const pairs = [];
+    this.forEach(item => pairs.push(item.toPair()));
+    return pairs;
+  }
 }
 
 module.exports = Queue;

--- a/types/prioqueue.d.ts
+++ b/types/prioqueue.d.ts
@@ -22,6 +22,7 @@ declare namespace queue {
     clear(): this;
     forEach(fn: (x: Item<T>) => void): this;
     isEmpty(): boolean;
+    toPairs(): Array<[number, T]>;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Queue#toPairs()`

Traverses the queue, from left to right, and for each traversed item stores in an array of size `n`, where `n` the size of the queue, an ordered-pair/2-tuple, where the first element is a `number` corresponding to the `priority` of the traversed item, and the last one is a value of type `any`, corresponding to the `value` stored in the traversed item.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
