### PR TITLE
Add new `Queue#dequeue()` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -94,6 +94,24 @@ class Queue {
     return this;
   }
 
+  dequeue() {
+    const front = this.peek();
+    const last = this._queue.pop();
+
+    if (!this.isEmpty()) {
+      let currentIndex = 0;
+      this._queue[0] = last;
+
+      while (!this._isPriorityOrdered(currentIndex)) {
+        const maxPriorityChildIndex = this._getMaxPriorityChildIndex(currentIndex);
+        this._swapItems(currentIndex, maxPriorityChildIndex);
+        currentIndex = maxPriorityChildIndex;
+      }
+    }
+
+    return front;
+  }
+
   enqueue(priority, value) {
     const item = new Item(priority, value);
     this._queue.push(item);

--- a/types/prioqueue.d.ts
+++ b/types/prioqueue.d.ts
@@ -20,6 +20,7 @@ declare namespace queue {
   export interface Instance<T> {
     readonly size: number;
     clear(): this;
+    dequeue(): Item<T> | undefined;
     enqueue(priority: number, value: T): this;
     forEach(fn: (x: Item<T>) => void): this;
     includes(value: T): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Queue#dequeue()`

Mutates the priority queue by removing the front item, which is also the item with the highest priority in the queue. Returns the removed item, if the priority queue is not empty, or `undefined` if it is.

Also, the corresponding TypeScript ambient declarations are included in the PR.
