### PR TITLE
Replace `any` default type for generics with `unknown`

### DIFF
--- a/types/prioqueue.d.ts
+++ b/types/prioqueue.d.ts
@@ -1,6 +1,6 @@
 declare namespace item {
   export interface Constructor {
-    new <T = any>(priority: number, value: T): Instance<T>;
+    new <T = unknown>(priority: number, value: T): Instance<T>;
   }
 
   export interface Instance<T> {
@@ -14,7 +14,7 @@ declare namespace queue {
   interface Item<T> extends item.Instance<T> {}
 
   export interface Constructor {
-    new <T = any>(comparatorFn: (x: Item<T>, y: Item<T>) => number): Instance<T>;
+    new <T = unknown>(comparatorFn: (x: Item<T>, y: Item<T>) => number): Instance<T>;
   }
 
   export interface Instance<T> {
@@ -37,8 +37,8 @@ declare namespace queue {
 }
 
 declare namespace prioqueue {
-  export interface Item<T = any> extends item.Instance<T> {}
-  export interface Queue<T = any> extends queue.Instance<T> {}
+  export interface Item<T = unknown> extends item.Instance<T> {}
+  export interface Queue<T = unknown> extends queue.Instance<T> {}
 }
 
 declare const prioqueue: {


### PR DESCRIPTION
## Description

The PR replaces the `any` type used as the default type for the generic type parameters with the more type-safe [`unknown`](https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type) type.